### PR TITLE
Add IndexError handling to search_list_t

### DIFF
--- a/ezldap/api.py
+++ b/ezldap/api.py
@@ -249,7 +249,7 @@ class Connection(ldap3.Connection):
                             # string coercion avoided for 1-element lists
                             v = v[0]
 
-                except KeyError:
+                except (KeyError, IndexError):
                     v = None
 
                 query[k].append(v)


### PR DESCRIPTION
Add IndexError, since sometimes it seems v at line 250 is a empty list (attribute is not filled)